### PR TITLE
Don't apply session duration by default

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -44,7 +44,7 @@ function restore_options() {
   chrome.storage.sync.get({
 	// Default values
     FileName: 'credentials',
-    ApplySessionDuration: 'yes',
+    ApplySessionDuration: 'no',
 	RoleArns: {}
   }, function(items) {
 	// Set filename


### PR DESCRIPTION
If there is a mismatch of session duration between the Okta AWS Federation app and the AWS IAM role definition, this plugin will fail to create the sts credentials file. 

kube2iam roles have a limited session duration of 1 hour. This is to help minimize impact of any leaked credentials through the app. We should not increase this duration to a full 8 hours. 

To work around this, the setting `ApplySessionDuration` exists. Disabling this, does not apply the Okta AWS Federation app session duration and instead relies on the AWS IAM role duration to expire credentials.

Prime: @salsify/hosting-platform 